### PR TITLE
changed max's name to martin

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -11,5 +11,6 @@ SPDX-License-Identifier: MIT
 * [Patrick Langer](https://github.com/RealLast)
 * [Thomas Kaar](https://github.com/ThomasKaar)
 * [Max Rosenblattl](https://github.com/max-rosenblattl)
+* [Maxwell A. Xu](https://github.com/maxxu05)
 * [Martin Maritsch](https://github.com/masquare)
 * [Paul Schmiedmayer](https://github.com/PSchmiedmayer)


### PR DESCRIPTION
# *Name of the PR*

## :recycle: Current situation & Problem
* During Paul's refactor in Commit b9a06f7, he changed the CONTRIBUTORS.MD accidentally and used my name, when it was Martin who contributed to the repo previously.
* Worth noting that previously, all co-authors were in this file, but  now the list is shorter. not sure if this is on purpose. if not on purpose, I can add everyone in. 


## :gear: Release Notes
* changed name from Maxwell Xu -> Martin Maritsch


## :books: Documentation
* n/a

## :white_check_mark: Testing
* only changed an .md file, so testing not needed


### Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).
