### PR TITLE
OpenTSLM-Flamingo SimpleNamespace fix

### DIFF
--- a/demo/huggingface/05_test_hf_ecg_qa_cot.py
+++ b/demo/huggingface/05_test_hf_ecg_qa_cot.py
@@ -20,7 +20,7 @@ from opentslm.model_config import PATCH_SIZE
 import torch
 
 # Model repository ID - change this to test different models
-REPO_ID = "OpenTSLM/llama-3.2-1b-ecg-sp"
+REPO_ID = "OpenTSLM/llama-3.2-1b-ecg-flamingo"
 
 def main():
     print("=" * 60)

--- a/demo/huggingface/06_eval_mimiciv_ecg.py
+++ b/demo/huggingface/06_eval_mimiciv_ecg.py
@@ -1,0 +1,259 @@
+# SPDX-FileCopyrightText: 2025 Stanford University, ETH Zurich, and the project authors (see CONTRIBUTORS.md)
+# SPDX-FileCopyrightText: 2025 This source file is part of the OpenTSLM open-source project.
+#
+# SPDX-License-Identifier: MIT
+"""
+Evaluation script for testing OpenTSLM models on MimicIV-ECG dataset with custom prompts.
+
+This script:
+1. Loads a pretrained model from HuggingFace Hub or local checkpoint
+2. Loads the MimicIV-ECG dataset
+3. Runs inference with custom prompts on all samples
+4. Stores outputs for later evaluation
+"""
+
+import sys
+import os
+from pathlib import Path
+
+# Add src directory to path to include new mimiciv_ecg module
+# This allows the script to work even when opentslm is installed via pip
+script_dir = Path(__file__).parent
+project_root = script_dir.parent.parent
+src_dir = project_root / "src"
+if src_dir.exists():
+    sys.path.insert(0, str(src_dir))
+
+import argparse
+import json
+from typing import List, Optional
+import torch
+from tqdm import tqdm
+
+from opentslm.model.llm.OpenTSLM import OpenTSLM
+from opentslm.time_series_datasets.mimiciv_ecg.MimicIVECGDataset import MimicIVECGDataset
+from opentslm.time_series_datasets.util import extend_time_series_to_match_patch_size_and_aggregate
+from torch.utils.data import DataLoader
+from opentslm.model_config import PATCH_SIZE
+
+
+# Define your custom prompts here
+# These will be applied to each sample in the dataset
+CUSTOM_PROMPTS = [
+    "Please summarize the ECG signal in a single paragraph and give a diagnosis",
+]
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Evaluate OpenTSLM model on MimicIV-ECG dataset with custom prompts"
+    )
+    parser.add_argument(
+        "--model_repo",
+        type=str,
+        default="OpenTSLM/llama-3.2-1b-ecg-sp",
+        help="HuggingFace repository ID or local path to model",
+    )
+    parser.add_argument(
+        "--split",
+        type=str,
+        default="test",
+        choices=["train", "test", "validation"],
+        help="Dataset split to evaluate on",
+    )
+    parser.add_argument(
+        "--ecg_data_dir",
+        type=str,
+        default=None,
+        help="Directory containing MimicIV-ECG data files (.dat/.hea). "
+             "If not provided, will try default location.",
+    )
+    parser.add_argument(
+        "--prompt",
+        type=str,
+        default=None,
+        help="Single prompt to use for all samples (overrides CUSTOM_PROMPTS list)",
+    )
+    parser.add_argument(
+        "--max_samples",
+        type=int,
+        default=None,
+        help="Maximum number of samples to evaluate (for testing)",
+    )
+    parser.add_argument(
+        "--output_dir",
+        type=str,
+        default="results/mimiciv_eval",
+        help="Directory to save evaluation results",
+    )
+    parser.add_argument(
+        "--batch_size",
+        type=int,
+        default=1,
+        help="Batch size for inference",
+    )
+    parser.add_argument(
+        "--max_new_tokens",
+        type=int,
+        default=500,
+        help="Maximum number of new tokens to generate",
+    )
+    parser.add_argument(
+        "--device",
+        type=str,
+        default=None,
+        help="Device to use (cuda/cpu). Auto-detected if not provided.",
+    )
+    parser.add_argument(
+        "--no_fix_lead_order",
+        action="store_true",
+        help="Don't reorder leads to match ECG-QA order",
+    )
+    
+    args = parser.parse_args()
+    
+    print("=" * 80)
+    print("MimicIV-ECG Evaluation Script")
+    print("=" * 80)
+    
+    # Determine device
+    if args.device is None:
+        device = "cuda" if torch.cuda.is_available() else "cpu"
+    else:
+        device = args.device
+    
+    print(f"\n📥 Loading model from {args.model_repo}...")
+    enable_lora = False
+    if "-sp" in args.model_repo or "sp" in args.model_repo.lower():
+        enable_lora = True
+    
+    try:
+        model = OpenTSLM.load_pretrained(
+            args.model_repo,
+            enable_lora=enable_lora,
+            device=device
+        )
+    except Exception as e:
+        print(f"Error loading model: {e}")
+        print("Make sure the model repository ID is correct or provide a local path.")
+        return
+    
+    # Determine which prompts to use
+    if args.prompt:
+        # Single prompt for all samples
+        custom_prompts = [args.prompt]
+        print(f"\n📝 Using single custom prompt: {args.prompt[:100]}...")
+    else:
+        # Use prompts defined in CUSTOM_PROMPTS list
+        custom_prompts = CUSTOM_PROMPTS
+        print(f"\n📝 Using {len(custom_prompts)} custom prompts from CUSTOM_PROMPTS list")
+    
+    # Create dataset
+    print(f"\n📊 Loading MimicIV-ECG {args.split} dataset...")
+    try:
+        test_dataset = MimicIVECGDataset(
+            split=args.split,
+            EOS_TOKEN=model.get_eos_token(),
+            max_samples=args.max_samples,
+            ecg_data_dir=args.ecg_data_dir,
+            custom_prompts=custom_prompts,
+            fix_lead_order=not args.no_fix_lead_order,
+        )
+    except Exception as e:
+        print(f"Error loading dataset: {e}")
+        print("\nTroubleshooting:")
+        print("1. Make sure MimicIV-ECG data is available in data/mimiciv_ecg/")
+        print("2. Set --ecg_data_dir to point to directory containing .dat/.hea files")
+        print("3. Check that ECG files exist for the ECG IDs in the dataset")
+        return
+    
+    print(f"Loaded {len(test_dataset)} samples")
+    
+    # Create data loader
+    test_loader = DataLoader(
+        test_dataset,
+        shuffle=False,
+        batch_size=args.batch_size,
+        collate_fn=lambda batch: extend_time_series_to_match_patch_size_and_aggregate(
+            batch, patch_size=PATCH_SIZE
+        ),
+    )
+    
+    # Create output directory
+    os.makedirs(args.output_dir, exist_ok=True)
+    
+    # Prepare output file
+    output_file = os.path.join(
+        args.output_dir,
+        f"mimiciv_eval_{args.split}_{args.model_repo.split('/')[-1]}.jsonl"
+    )
+    
+    print(f"\n🔍 Running inference on {len(test_dataset)} samples...")
+    print(f"💾 Results will be saved to: {output_file}")
+    print("=" * 80)
+    
+    all_results = []
+    
+    # Iterate over dataset
+    for batch_idx, batch in enumerate(tqdm(test_loader, desc="Evaluating")):
+        try:
+            # Generate predictions
+            predictions = model.generate(batch, max_new_tokens=args.max_new_tokens)
+            
+            # Debug: Print first batch predictions
+            if batch_idx == 0:
+                print(f"\n🔍 DEBUG: First batch predictions:")
+                print(f"  Number of predictions: {len(predictions)}")
+                for i, pred in enumerate(predictions):
+                    print(f"  Prediction {i}: {repr(pred[:200]) if pred else 'EMPTY'}")
+                    print(f"  Prediction {i} length: {len(pred) if pred else 0}")
+            
+            # Process each sample in the batch
+            for sample_idx, (sample, pred) in enumerate(zip(batch, predictions)):
+                result = {
+                    "sample_id": sample.get("sample_id", batch_idx * args.batch_size + sample_idx),
+                    "ecg_id": sample.get("ecg_id", "N/A"),
+                    "template_id": sample.get("template_id", "N/A"),
+                    "question_type": sample.get("question_type", "N/A"),
+                    "pre_prompt": sample.get("pre_prompt", ""),
+                    "post_prompt": sample.get("post_prompt", ""),
+                    "model_output": pred,
+                    "gold_answer": sample.get("answer", ""),
+                }
+                
+                all_results.append(result)
+                
+                # Write incrementally to file
+                with open(output_file, 'a') as f:
+                    f.write(json.dumps(result) + '\n')
+        
+        except Exception as e:
+            print(f"\n⚠️  Error processing batch {batch_idx}: {e}")
+            import traceback
+            traceback.print_exc()
+            continue
+    
+    # Also save as JSON for easier loading
+    json_output_file = output_file.replace('.jsonl', '.json')
+    with open(json_output_file, 'w') as f:
+        json.dump(all_results, f, indent=2)
+    
+    print(f"\n✅ Evaluation complete!")
+    print(f"   Processed {len(all_results)} samples")
+    print(f"   Results saved to:")
+    print(f"     - {output_file} (JSONL format)")
+    print(f"     - {json_output_file} (JSON format)")
+    
+    # Print summary
+    if len(all_results) > 0:
+        print(f"\n📊 Summary:")
+        print(f"   Total samples: {len(all_results)}")
+        print(f"   Model: {args.model_repo}")
+        print(f"   Split: {args.split}")
+        if custom_prompts:
+            print(f"   Custom prompts: {len(custom_prompts)}")
+        print(f"\n   Sample outputs saved to: {args.output_dir}")
+
+
+if __name__ == "__main__":
+    main()

--- a/demo/huggingface/06_eval_mimiciv_ecg.py
+++ b/demo/huggingface/06_eval_mimiciv_ecg.py
@@ -39,23 +39,78 @@ from opentslm.model_config import PATCH_SIZE
 
 # Define your custom prompts here
 # These will be applied to each sample in the dataset
-CUSTOM_PROMPTS = [
-    "Summarize this ECG and highlight any clinically relevant findings.",
-    "Provide an overall interpretation of this ECG.",
-    "What are your findings on this ECG?",
-    "Describe this ECG in a clinically meaningful way.",
-    "Interpret this ECG and describe any abnormalities.",
-    "What stands out as abnormal on this ECG?",
-    "What are the key findings on this ECG?",
-    "Are there any clinically significant abnormalities on this ECG?",
-    "Based on this ECG, what is the most likely diagnosis?",
-    "What diagnoses should be considered based on this ECG?",
-    "Does this ECG show signs of arrhythmia?",
-    "Does this ECG show signs of atrial fibrillation?",
-    "Are there any ST-segment or T-wave abnormalities?",
-    "Are there any signs of ischemia or myocardial infarction?",
-    "Does this ECG show evidence of structural heart disease?",
+
+# List of allowed diagnoses
+ALLOWED_DIAGNOSES = [
+    "non-diagnostic T abnormalities", "non-specific ST changes", "digitalis-effect", "long QT-interval", 
+    "normal ECG", "inferior myocardial infarction", "anteroseptal myocardial infarction", 
+    "left ventricular hypertrophy", "left anterior fascicular block", "non-specific ischemic", 
+    "incomplete right bundle branch block", "first degree AV block", 
+    "non-specific intraventricular conduction disturbance (block)", "ischemic in anterolateral leads", 
+    "complete right bundle branch block", "complete left bundle branch block", 
+    "inferolateral myocardial infarction", "left atrial overload/enlargement", 
+    "anterior myocardial infarction", "anterolateral myocardial infarction", 
+    "ischemic in inferior leads", "subendocardial injury in anteroseptal leads", 
+    "lateral myocardial infarction", "ischemic in inferolateral leads", 
+    "left posterior fascicular block", "ischemic in anteroseptal leads", 
+    "subendocardial injury in anterolateral leads", "ischemic in lateral leads", 
+    "right ventricular hypertrophy", "ST-T changes compatible with ventricular aneurysm", 
+    "right atrial overload/enlargement", "electrolytic disturbance or drug (former EDIS)", 
+    "Wolf-Parkinson-White syndrome", "incomplete left bundle branch block", 
+    "inferoposterolateral myocardial infarction", "ischemic in anterior leads", 
+    "inferoposterior myocardial infarction", "septal hypertrophy", 
+    "subendocardial injury in inferior leads", "subendocardial injury in lateral leads", 
+    "posterior myocardial infarction", "third degree AV block", 
+    "subendocardial injury in inferolateral leads", "second degree AV block", 
+    "abnormal QRS", "ventricular premature complex", "non-specific ST depression", 
+    "voltage criteria (QRS) for left ventricular hypertrophy", "Q waves present", 
+    "low amplitude T-waves", "non-specific T-wave changes", "atrial premature complex", 
+    "prolonged PR interval", "inverted T-waves", 
+    "low QRS voltages in the frontal and horizontal leads", "high QRS voltage", 
+    "T-wave abnormality", "non-specific ST elevation", "premature complex(es)", 
+    "sinus rhythm", "atrial fibrillation", "sinus tachycardia", "sinus arrhythmia", 
+    "sinus bradycardia", "normal functioning artificial pacemaker", 
+    "supraventricular arrhythmia", "bigeminal pattern (unknown origin, SV or Ventricular)", 
+    "atrial flutter", "supraventricular tachycardia", 
+    "paroxysmal supraventricular tachycardia", 
+    "trigeminal pattern (unknown origin, SV or Ventricular)"
 ]
+
+# Prompt version 1: WITH the diagnoses list
+prompt_with_list = f"""You are an expert cardiologist analyzing an ECG (electrocardiogram).
+
+Your task is to examine the ECG signal and provide a diagnosis.
+
+Please describe this ECG and diagnose it with one or more of the following conditions: {', '.join(ALLOWED_DIAGNOSES)}
+
+Then for each diagnosis, please explain your reasoning."""
+
+# Prompt version 2: WITHOUT the diagnoses list
+prompt_without_list = """You are an expert cardiologist analyzing an ECG (electrocardiogram).
+
+Your task is to examine the ECG signal and provide a diagnosis.
+
+Please describe this ECG and provide one or more diagnoses.
+
+Then for each diagnosis, please explain your reasoning."""
+
+CUSTOM_PROMPTS = [prompt_with_list, prompt_without_list]
+#    "Summarize this ECG and highlight any clinically relevant findings.",
+#    "Provide an overall interpretation of this ECG.",
+#    "What are your findings on this ECG?",
+#    "Describe this ECG in a clinically meaningful way.",
+#    "Interpret this ECG and describe any abnormalities.",
+#    "What stands out as abnormal on this ECG?",
+#    "What are the key findings on this ECG?",
+#    "Are there any clinically significant abnormalities on this ECG?",
+#    "Based on this ECG, what is the most likely diagnosis?",
+#    "What diagnoses should be considered based on this ECG?",
+#    "Does this ECG show signs of arrhythmia?",
+#    "Does this ECG show signs of atrial fibrillation?",
+#    "Are there any ST-segment or T-wave abnormalities?",
+#    "Are there any signs of ischemia or myocardial infarction?",
+#    "Does this ECG show evidence of structural heart disease?",
+#]
 
 
 def main():
@@ -65,7 +120,7 @@ def main():
     parser.add_argument(
         "--model_repo",
         type=str,
-        default="OpenTSLM/llama-3.2-1b-ecg-sp",
+        default="OpenTSLM/llama-3.2-3b-ecg-sp",
         help="HuggingFace repository ID or local path to model",
     )
     parser.add_argument(
@@ -123,6 +178,12 @@ def main():
         action="store_true",
         help="Don't reorder leads to match ECG-QA order",
     )
+    parser.add_argument(
+        "--use_custom_prompt_directly",
+        action="store_true",
+        help="Use custom prompt as-is without default pre/post-prompt wrapper. "
+             "Useful when custom prompt contains its own instructions.",
+    )
     
     args = parser.parse_args()
     
@@ -172,6 +233,7 @@ def main():
             ecg_data_dir=args.ecg_data_dir,
             custom_prompts=custom_prompts,
             fix_lead_order=not args.no_fix_lead_order,
+            use_custom_prompt_directly=args.use_custom_prompt_directly,
         )
     except Exception as e:
         print(f"Error loading dataset: {e}")

--- a/demo/huggingface/06_eval_mimiciv_ecg.py
+++ b/demo/huggingface/06_eval_mimiciv_ecg.py
@@ -40,7 +40,21 @@ from opentslm.model_config import PATCH_SIZE
 # Define your custom prompts here
 # These will be applied to each sample in the dataset
 CUSTOM_PROMPTS = [
-    "Please summarize the ECG signal in a single paragraph and give a diagnosis",
+    "Summarize this ECG and highlight any clinically relevant findings.",
+    "Provide an overall interpretation of this ECG.",
+    "What are your findings on this ECG?",
+    "Describe this ECG in a clinically meaningful way.",
+    "Interpret this ECG and describe any abnormalities.",
+    "What stands out as abnormal on this ECG?",
+    "What are the key findings on this ECG?",
+    "Are there any clinically significant abnormalities on this ECG?",
+    "Based on this ECG, what is the most likely diagnosis?",
+    "What diagnoses should be considered based on this ECG?",
+    "Does this ECG show signs of arrhythmia?",
+    "Does this ECG show signs of atrial fibrillation?",
+    "Are there any ST-segment or T-wave abnormalities?",
+    "Are there any signs of ischemia or myocardial infarction?",
+    "Does this ECG show evidence of structural heart disease?",
 ]
 
 

--- a/src/opentslm/model/llm/OpenTSLMFlamingo.py
+++ b/src/opentslm/model/llm/OpenTSLMFlamingo.py
@@ -344,9 +344,19 @@ class OpenTSLMFlamingo(TimeSeriesLLM):
         # Remove prefixes ('model.' or 'llm.') if present in checkpoint keys
         # The checkpoint may have been saved with keys prefixed with 'model.' or 'llm.'
         # but the actual Flamingo model expects keys without these prefixes
+        # Also filter out 'old_decoder_blocks' keys - these are redundant aliases.
+        # old_decoder_blocks is a reference to the same ModuleList as model.layers (for LLaMA),
+        # so the weights are already saved/loaded via the actual layer path (e.g., model.layers.0.self_attn.q_proj.weight).
+        # Loading via model.layers automatically updates old_decoder_blocks since it's just a reference.
         new_model_state = {}
         prefix_removed_count = 0
+        old_decoder_blocks_filtered = 0
         for k, v in model_state.items():
+            # Skip old_decoder_blocks keys - these are redundant (weights loaded via model.layers path)
+            if "old_decoder_blocks" in k:
+                old_decoder_blocks_filtered += 1
+                continue
+            
             new_key = k
             # Remove 'llm.' prefix if present (common when saved as checkpoint["llm"])
             if new_key.startswith("llm."):
@@ -361,6 +371,8 @@ class OpenTSLMFlamingo(TimeSeriesLLM):
         
         if prefix_removed_count > 0:
             print(f"ℹ️  Removed prefix from {prefix_removed_count} checkpoint keys")
+        if old_decoder_blocks_filtered > 0:
+            print(f"ℹ️  Filtered out {old_decoder_blocks_filtered} redundant old_decoder_blocks keys (weights loaded via model.layers path)")
 
         # Load state dict with strict=False to handle missing/unexpected keys
         # The checkpoint contains state for self.model (the Flamingo model), not self

--- a/src/opentslm/model/llm/OpenTSLMFlamingo.py
+++ b/src/opentslm/model/llm/OpenTSLMFlamingo.py
@@ -146,7 +146,18 @@ class OpenTSLMFlamingo(TimeSeriesLLM):
             # TODO: investigate also training the output embeddings when untied
 
         # additonally unfreeze encoder
-        model.vision_encoder.requires_grad_(True)
+        # Ensure vision_encoder is a PyTorch module (not a SimpleNamespace)
+        if hasattr(model.vision_encoder, 'requires_grad_'):
+            model.vision_encoder.requires_grad_(True)
+        else:
+            # If vision_encoder is a SimpleNamespace, extract the actual encoder
+            if hasattr(model.vision_encoder, 'visual'):
+                model.vision_encoder = model.vision_encoder.visual
+                model.vision_encoder.requires_grad_(True)
+            else:
+                raise ValueError(
+                    f"vision_encoder is not a PyTorch module. Got type: {type(model.vision_encoder)}"
+                )
 
         self.model = model
         self.llm = model
@@ -256,14 +267,20 @@ class OpenTSLMFlamingo(TimeSeriesLLM):
                     batch, include_labels=True
                 )
 
+                # Prepare generation kwargs
+                # Note: eos_token_id and pad_token_id are not passed to Flamingo.generate()
+                # as the installed open-flamingo version doesn't accept them in kwargs.
+                # The underlying language model will use its default eos_token_id.
+                generation_kwargs = {
+                    "max_new_tokens": max_new_tokens,
+                    **generate_kwargs,
+                }
+                
                 gen_ids = self.llm.generate(
                     vision_x=images,
                     lang_x=input_ids,
                     attention_mask=attention_mask,
-                    max_new_tokens=max_new_tokens,
-                    eos_token_id=self.text_tokenizer.eos_token_id,
-                    pad_token_id=self.text_tokenizer.pad_token_id,
-                    **generate_kwargs,
+                    **generation_kwargs,
                 )
 
                 # Remove input ids from generation
@@ -324,14 +341,30 @@ class OpenTSLMFlamingo(TimeSeriesLLM):
         if hasattr(self, "module"):
             model_state = {f"module.{k}": v for k, v in model_state.items()}
 
-        # Remove 'model.' prefix if present in checkpoint keys
-        if all(k.startswith("model.") for k in model_state.keys()):
-            model_state = {
-                k.replace("model.", "", 1): v for k, v in model_state.items()
-            }
+        # Remove prefixes ('model.' or 'llm.') if present in checkpoint keys
+        # The checkpoint may have been saved with keys prefixed with 'model.' or 'llm.'
+        # but the actual Flamingo model expects keys without these prefixes
+        new_model_state = {}
+        prefix_removed_count = 0
+        for k, v in model_state.items():
+            new_key = k
+            # Remove 'llm.' prefix if present (common when saved as checkpoint["llm"])
+            if new_key.startswith("llm."):
+                new_key = new_key[4:]  # Remove "llm." (4 characters)
+                prefix_removed_count += 1
+            # Remove 'model.' prefix if present
+            elif new_key.startswith("model."):
+                new_key = new_key[6:]  # Remove "model." (6 characters)
+                prefix_removed_count += 1
+            new_model_state[new_key] = v
+        model_state = new_model_state
+        
+        if prefix_removed_count > 0:
+            print(f"ℹ️  Removed prefix from {prefix_removed_count} checkpoint keys")
 
         # Load state dict with strict=False to handle missing/unexpected keys
-        missing_keys, unexpected_keys = self.load_state_dict(model_state, strict=False)
+        # The checkpoint contains state for self.model (the Flamingo model), not self
+        missing_keys, unexpected_keys = self.model.load_state_dict(model_state, strict=False)
         if missing_keys:
             print(f"⚠️  Warning: Missing keys when loading checkpoint:")
             for key in missing_keys[:10]:

--- a/src/opentslm/time_series_datasets/constants.py
+++ b/src/opentslm/time_series_datasets/constants.py
@@ -10,5 +10,5 @@ import os
 # Path to this file's directory
 BASE_DIR = os.path.dirname(os.path.abspath(__file__))
 
-# Path to raw data directory
-RAW_DATA = os.path.join(BASE_DIR, "..", "..", "data")
+# Path to raw data directory (go up 3 levels: time_series_datasets -> opentslm -> src -> project root)
+RAW_DATA = os.path.join(BASE_DIR, "..", "..", "..", "data")

--- a/src/opentslm/time_series_datasets/mimiciv_ecg/MimicIVECGDataset.py
+++ b/src/opentslm/time_series_datasets/mimiciv_ecg/MimicIVECGDataset.py
@@ -1,0 +1,478 @@
+# SPDX-FileCopyrightText: 2025 Stanford University, ETH Zurich, and the project authors (see CONTRIBUTORS.md)
+# SPDX-FileCopyrightText: 2025 This source file is part of the OpenTSLM open-source project.
+#
+# SPDX-License-Identifier: MIT
+
+from datasets import Dataset
+from typing import List, Tuple, Literal, Optional, Dict, Callable
+from functools import partial
+import numpy as np
+import os
+
+# Try to import wfdb, raise error if not available
+try:
+    import wfdb
+except ImportError:
+    raise ImportError(
+        "wfdb library is required for ECG data loading. "
+        "Please install it with: pip install wfdb"
+    )
+
+from opentslm.prompt.text_time_series_prompt import TextTimeSeriesPrompt
+from opentslm.time_series_datasets.QADataset import QADataset
+from opentslm.time_series_datasets.mimiciv_ecg.mimiciv_ecg_loader import (
+    load_mimiciv_ecg_splits,
+    get_mimiciv_ecg_path,
+)
+import torch
+
+
+# ECG-QA lead order: I, II, III, aVR, aVL, aVF, V1, V2, V3, V4, V5, V6
+ECG_QA_LEAD_ORDER = ["I", "II", "III", "aVR", "aVL", "aVF", "V1", "V2", "V3", "V4", "V5", "V6"]
+
+# Common MimicIV lead orders (may vary)
+# Some MimicIV datasets have aVR and aVF swapped
+MIMICIV_ALTERNATIVE_ORDER = ["I", "II", "III", "aVF", "aVL", "aVR", "V1", "V2", "V3", "V4", "V5", "V6"]
+
+
+class MimicIVECGDataset(QADataset):
+    """
+    MimicIV-ECG Dataset for question answering with electrocardiogram data.
+    
+    This dataset loads ECG time series data from MimicIV-ECG and allows
+    custom prompts to be provided for evaluation.
+    
+    Requires: pip install wfdb
+    """
+
+    def __init__(
+        self,
+        split: Literal["train", "test", "validation"],
+        EOS_TOKEN: str,
+        format_sample_str: bool = False,
+        time_series_format_function=None,
+        max_samples: int = None,
+        ecg_data_dir: Optional[str] = None,
+            custom_prompts: Optional[List[str]] = None,  # Required for MimicIV-ECG
+        pre_prompt_template: Optional[str] = None,
+        post_prompt_template: Optional[str] = None,
+        fix_lead_order: bool = True,
+    ):
+        """
+        Initialize MimicIV-ECG Dataset.
+        
+        Args:
+            split: Dataset split to load
+            EOS_TOKEN: End-of-sequence token
+            format_sample_str: Whether to format samples as strings
+            time_series_format_function: Function to format time series data
+            max_samples: Maximum number of samples per split (for testing)
+            ecg_data_dir: Directory containing ECG data files (.dat/.hea)
+            custom_prompts: Optional list of custom prompts to use for each sample.
+                          If provided, these will be used instead of dataset questions.
+                          Should be a list with one prompt per sample, or a function
+                          that takes (sample_idx, sample) and returns a prompt.
+            pre_prompt_template: Optional template for pre-prompt. Can use {question} placeholder.
+            post_prompt_template: Optional template for post-prompt.
+            fix_lead_order: If True, reorder leads to match ECG-QA order (I, II, III, aVR, aVL, aVF, V1-V6)
+        """
+        self.max_samples = max_samples
+        self.ecg_data_dir = ecg_data_dir
+        self.custom_prompts = custom_prompts
+        self.pre_prompt_template = pre_prompt_template
+        self.post_prompt_template = post_prompt_template
+        self.fix_lead_order = fix_lead_order
+        
+        # Override parent initialization to handle NaN samples
+        self.EOS_TOKEN = EOS_TOKEN
+        if not hasattr(self.__class__, "loaded"):
+            train, val, test = self._load_splits()
+
+            format_function = partial(self._format_sample_str, time_series_format_function) if format_sample_str else self._format_sample
+           
+            from tqdm import tqdm
+            
+            # Format samples and skip those with NaN values
+            def format_with_skip(split_name, dataset):
+                formatted_samples = []
+                skipped_count = 0
+                for sample in tqdm(dataset, desc=f"Formatting {split_name} samples"):
+                    try:
+                        formatted = format_function(sample)
+                        formatted_samples.append(formatted)
+                    except (ValueError, RuntimeError) as e:
+                        if "NaN" in str(e) or "Inf" in str(e) or "SAMPLE_SKIP" in str(e):
+                            skipped_count += 1
+                            continue
+                        raise
+                if skipped_count > 0:
+                    print(f"⚠️  Excluded {skipped_count} samples with NaN/Inf values from {split_name} split")
+                return formatted_samples
+            
+            print("Formatting training samples...")
+            self.__class__._train_dataset = format_with_skip("training", train)
+            
+            print("Formatting validation samples...")
+            self.__class__._validation_dataset = format_with_skip("validation", val)
+            
+            print("Formatting test samples...")
+            self.__class__._test_dataset = format_with_skip("test", test)
+
+            self.__class__.loaded = True
+
+        match split:
+            case "train":
+                self.dataset = self.__class__._train_dataset
+            case "validation":
+                self.dataset = self.__class__._validation_dataset
+            case "test":
+                self.dataset = self.__class__._test_dataset
+            case _:
+                raise RuntimeError(
+                    "Split must be a literal of 'train', 'test', or 'validation'"
+                )
+
+    def _load_splits(self) -> Tuple[Dataset, Dataset, Dataset]:
+        """Load the MimicIV-ECG dataset splits."""
+        print("Loading MimicIV-ECG dataset splits...")
+        train, val, test = load_mimiciv_ecg_splits(
+            ecg_data_dir=self.ecg_data_dir,
+            max_samples=self.max_samples
+        )
+        return train, val, test
+
+    def _get_answer(self, row) -> str:
+        """Extract the answer from the row."""
+        # For evaluation, we might not have ground truth answers
+        # Return empty string or placeholder
+        if isinstance(row.get("answer"), list) and len(row.get("answer", [])) > 0:
+            return str(row["answer"][0])
+        return str(row.get("answer", ""))
+
+    def _get_pre_prompt(self, row) -> str:
+        """Generate the pre-prompt with custom prompt."""
+        # Custom prompts must be provided - no fallback to dataset questions
+        if self.custom_prompts is None:
+            raise ValueError(
+                "custom_prompts must be provided. MimicIV-ECG dataset requires explicit prompts."
+            )
+        
+        if callable(self.custom_prompts):
+            # Function: call with row data
+            sample_idx = row.get("sample_id", 0)
+            question = self.custom_prompts(sample_idx, row)
+        elif isinstance(self.custom_prompts, list):
+            # List: use sample_id if available, otherwise hash row for consistency
+            sample_idx = row.get("sample_id", None)
+            if sample_idx is not None:
+                prompt_idx = sample_idx % len(self.custom_prompts)
+            else:
+                # Use hash of ecg_id for consistent mapping
+                ecg_ids = row.get("ecg_id", [])
+                if ecg_ids:
+                    prompt_idx = hash(str(ecg_ids[0])) % len(self.custom_prompts)
+                else:
+                    prompt_idx = 0
+            question = self.custom_prompts[prompt_idx]
+        else:
+            # Single string: use for all samples
+            question = str(self.custom_prompts)
+        
+        # Use template if provided
+        if self.pre_prompt_template:
+            pre_prompt = self.pre_prompt_template.format(question=question)
+        else:
+            # Default pre-prompt - match ECGQACoTQADataset format
+            # Note: MimicIV doesn't have clinical_context, so we omit that line
+            pre_prompt = f"""You are an expert cardiologist analyzing an ECG (electrocardiogram). 
+
+Your task is to examine the ECG signal and answer the following medical question:
+
+Question: {question}
+
+Instructions:
+- Begin by analyzing the time series without assuming a specific answer.
+- Think step-by-step about what the observed patterns suggest regarding the cardiac condition.
+- Write your rationale as a single, natural paragraph — do not use bullet points, numbered steps, or section headings.
+- Do **not** mention any final answer until the very end.
+- Consider the ECG morphology, intervals, and any abnormalities that relate to the question."""
+        
+        return pre_prompt
+
+    def _get_post_prompt(self, row) -> str:
+        """Generate the post-prompt with instructions."""
+        if self.post_prompt_template:
+            return self.post_prompt_template.strip()
+        
+        # Default post-prompt - match ECGQACoTQADataset format
+        return """Based on your analysis of the ECG data, provide your answer.
+Make sure that your last word is the answer. You MUST end your response with "Answer: "
+"""
+
+    def _reorder_leads_to_ecg_qa_order(
+        self, ecg_signal: np.ndarray, record: wfdb.Record
+    ) -> Tuple[np.ndarray, List[str]]:
+        """
+        Reorder ECG leads to match ECG-QA order: I, II, III, aVR, aVL, aVF, V1-V6.
+        
+        Args:
+            ecg_signal: ECG signal array (samples, leads)
+            record: wfdb Record object with lead names
+        
+        Returns:
+            Tuple of (reordered_signal, lead_names)
+        """
+        if not self.fix_lead_order:
+            # Return original order
+            lead_names = record.sig_name if hasattr(record, 'sig_name') else [
+                f"Lead_{i}" for i in range(ecg_signal.shape[1])
+            ]
+            return ecg_signal, lead_names
+        
+        # Get lead names from record
+        if hasattr(record, 'sig_name') and record.sig_name:
+            record_lead_names = [name.strip().upper() for name in record.sig_name]
+        else:
+            # Fallback: assume standard order
+            record_lead_names = ECG_QA_LEAD_ORDER[:ecg_signal.shape[1]]
+        
+        # Create mapping from record order to ECG-QA order
+        reordered_signal = np.zeros_like(ecg_signal)
+        reordered_lead_names = []
+        
+        for target_idx, target_lead in enumerate(ECG_QA_LEAD_ORDER):
+            if target_idx >= ecg_signal.shape[1]:
+                break
+            
+            # Try to find the lead in the record
+            found = False
+            for record_idx, record_lead in enumerate(record_lead_names):
+                # Normalize lead names for comparison
+                normalized_record = record_lead.replace("AVR", "AVR").replace("AVL", "AVL").replace("AVF", "AVF")
+                normalized_target = target_lead.replace("aVR", "AVR").replace("aVL", "AVL").replace("aVF", "AVF")
+                
+                if normalized_record == normalized_target or record_lead == target_lead:
+                    reordered_signal[:, target_idx] = ecg_signal[:, record_idx]
+                    reordered_lead_names.append(target_lead)
+                    found = True
+                    break
+            
+            if not found:
+                # If lead not found, try alternative order (aVR/aVF swapped)
+                if target_lead == "aVR":
+                    # Try aVF position
+                    for record_idx, record_lead in enumerate(record_lead_names):
+                        if "AVF" in record_lead.upper():
+                            reordered_signal[:, target_idx] = ecg_signal[:, record_idx]
+                            reordered_lead_names.append(target_lead)
+                            found = True
+                            break
+                elif target_lead == "aVF":
+                    # Try aVR position
+                    for record_idx, record_lead in enumerate(record_lead_names):
+                        if "AVR" in record_lead.upper():
+                            reordered_signal[:, target_idx] = ecg_signal[:, record_idx]
+                            reordered_lead_names.append(target_lead)
+                            found = True
+                            break
+                
+                if not found:
+                    # If still not found, use the lead at this position
+                    if target_idx < len(record_lead_names):
+                        reordered_signal[:, target_idx] = ecg_signal[:, target_idx]
+                        reordered_lead_names.append(ECG_QA_LEAD_ORDER[target_idx])
+                    else:
+                        # Pad with zeros if we run out of leads
+                        reordered_lead_names.append(ECG_QA_LEAD_ORDER[target_idx])
+        
+        return reordered_signal, reordered_lead_names
+
+    def _get_text_time_series_prompt_list(self, row) -> List[TextTimeSeriesPrompt]:
+        """Load ECG data and convert to TextTimeSeriesPrompt format."""
+        ecg_prompts = []
+        ecg_paths = row.get("ecg_paths", [])
+
+        if not ecg_paths:
+            # Fallback: try to construct path from ecg_id
+            ecg_id = row.get("ecg_id", [])
+            if ecg_id and len(ecg_id) > 0:
+                ecg_path = get_mimiciv_ecg_path(ecg_id[0], self.ecg_data_dir) + ".dat"
+                ecg_paths = [ecg_path]
+
+        if not ecg_paths:
+            raise ValueError(f"No ECG paths found for sample. Row data: {row}")
+
+        for i, ecg_path in enumerate(ecg_paths):
+            # Load ECG data using wfdb
+            base_path = ecg_path.replace(".dat", "").replace(".hea", "")
+
+            if not os.path.exists(base_path + ".dat"):
+                raise FileNotFoundError(f"ECG data file not found: {base_path}.dat")
+
+            if not os.path.exists(base_path + ".hea"):
+                raise FileNotFoundError(f"ECG header file not found: {base_path}.hea")
+
+            try:
+                # Read the ECG record
+                record = wfdb.rdrecord(base_path)
+            except Exception as e:
+                raise RuntimeError(
+                    f"Failed to read ECG record from {base_path}: {str(e)}"
+                )
+
+            # Get the signal data - shape is (samples, leads)
+            ecg_signal = record.p_signal  # Physical signal
+
+            if ecg_signal is None:
+                raise ValueError(f"ECG signal is None for file {base_path}")
+
+            if ecg_signal.shape[0] == 0:
+                raise ValueError(
+                    f"ECG signal is empty (0 samples) for file {base_path}"
+                )
+
+            # Reorder leads to match ECG-QA order if requested
+            if self.fix_lead_order:
+                ecg_signal, lead_names = self._reorder_leads_to_ecg_qa_order(
+                    ecg_signal, record
+                )
+            else:
+                lead_names = (
+                    record.sig_name
+                    if hasattr(record, "sig_name") and record.sig_name
+                    else [f"Lead_{j}" for j in range(ecg_signal.shape[1])]
+                )
+
+            # Process each lead
+            n_leads = min(12, ecg_signal.shape[1])  # Use up to 12 leads
+
+            for lead_idx in range(n_leads):
+                if len(ecg_signal.shape) > 1:
+                    lead_signal = ecg_signal[:, lead_idx]
+                else:
+                    lead_signal = ecg_signal
+
+                if len(lead_signal) == 0:
+                    raise ValueError(f"Lead {lead_idx} is empty for file {base_path}")
+
+                # Downsample from 500Hz to ~100Hz for efficiency (take every 5th sample)
+                if len(lead_signal) > 1000:
+                    downsampled_signal = lead_signal[::5]
+                else:
+                    downsampled_signal = lead_signal
+
+                if len(downsampled_signal) == 0:
+                    raise ValueError(
+                        f"Downsampled signal is empty for lead {lead_idx} in file {base_path}"
+                    )
+
+                # Check for NaN/Inf values in the signal before processing
+                if np.any(np.isnan(downsampled_signal)) or np.any(np.isinf(downsampled_signal)):
+                    # Skip this sample - return empty list to signal it should be skipped
+                    raise ValueError(
+                        f"NaN/Inf values detected in ECG signal for lead {lead_idx} "
+                        f"in file {base_path}. Sample will be excluded."
+                    )
+                
+                # Normalize the signal
+                mean_val = float(np.mean(downsampled_signal))
+                std_val = float(np.std(downsampled_signal))
+
+                if np.isnan(mean_val) or np.isnan(std_val):
+                    raise ValueError(
+                        f"NaN values detected in ECG signal statistics for lead {lead_idx} "
+                        f"in file {base_path}. Sample will be excluded."
+                    )
+
+                if std_val > 1e-6:  # Avoid division by zero
+                    normalized_signal = (downsampled_signal - mean_val) / std_val
+                else:
+                    print(
+                        f"Warning: Lead {lead_idx} in file {base_path} has very low std deviation "
+                        f"({std_val}), signal may be flat"
+                    )
+                    normalized_signal = downsampled_signal - mean_val
+
+                # Verify normalized signal is valid
+                if np.any(np.isnan(normalized_signal)) or np.any(
+                    np.isinf(normalized_signal)
+                ):
+                    raise ValueError(
+                        f"Invalid values (NaN/Inf) in normalized signal for lead {lead_idx} "
+                        f"in file {base_path}"
+                    )
+
+                # Create lead name - match exact format from ECGQACoTQADataset
+                lead_names_list = ["I", "II", "III", "aVR", "aVL", "aVF", "V1", "V2", "V3", "V4", "V5", "V6"]
+                lead_name = lead_names_list[lead_idx] if lead_idx < len(lead_names_list) else f"Lead_{lead_idx}"
+                
+                ecg_label = f"This is ECG Lead {lead_name}"
+                if len(ecg_paths) > 1:
+                    ecg_label += f" (Recording {i+1})"
+                    
+                ecg_label += f", it has mean {mean_val:.4f} and std {std_val:.4f}:"
+
+                try:
+                    ecg_prompts.append(
+                        TextTimeSeriesPrompt(ecg_label, normalized_signal.tolist())
+                    )
+                except Exception as e:
+                    raise RuntimeError(
+                        f"Failed to create TextTimeSeriesPrompt for lead {lead_name} "
+                        f"in file {base_path}: {str(e)}"
+                    )
+
+        if not ecg_prompts:
+            raise RuntimeError(
+                f"No ECG prompts were created for sample. ECG paths attempted: {ecg_paths}"
+            )
+
+        return ecg_prompts
+
+    def _format_sample(self, row):
+        # Call parent method to get the standard formatted sample
+        formatted_sample = super()._format_sample(row)
+
+        # Add metadata if available
+        if "ecg_id" in row:
+            formatted_sample["ecg_id"] = row["ecg_id"]
+        if "template_id" in row:
+            formatted_sample["template_id"] = row.get("template_id")
+        if "question_type" in row:
+            formatted_sample["question_type"] = row.get("question_type")
+        if "sample_id" in row:
+            formatted_sample["sample_id"] = row.get("sample_id")
+
+        return formatted_sample
+
+
+if __name__ == "__main__":
+    # Test the dataset
+    print("Testing MimicIVECGDataset...")
+
+    try:
+        # Test with just 5 samples per split for faster testing
+        dataset = MimicIVECGDataset(
+            split="test", EOS_TOKEN="", max_samples=5
+        )
+
+        print(f"Dataset size: {len(dataset)}")
+
+        if len(dataset) > 0:
+            sample = dataset[0]
+            print("\nSample keys:", sample.keys())
+            print("Sample question:", sample.get("pre_prompt", "N/A")[:200])
+            print("Sample ECG IDs:", sample.get("ecg_id", "N/A"))
+            if "time_series_text" in sample:
+                print("Time series prompts:", len(sample["time_series_text"]))
+                if len(sample["time_series_text"]) > 0:
+                    first_ts = sample["time_series_text"][0]
+                    if hasattr(first_ts, "text"):
+                        print("First time series label:", first_ts.text)
+                        print("First time series length:", len(first_ts.time_series))
+
+    except Exception as e:
+        print(f"Error testing dataset: {e}")
+        import traceback
+
+        traceback.print_exc()

--- a/src/opentslm/time_series_datasets/mimiciv_ecg/MimicIVECGDataset.py
+++ b/src/opentslm/time_series_datasets/mimiciv_ecg/MimicIVECGDataset.py
@@ -57,6 +57,7 @@ class MimicIVECGDataset(QADataset):
         pre_prompt_template: Optional[str] = None,
         post_prompt_template: Optional[str] = None,
         fix_lead_order: bool = True,
+        use_custom_prompt_directly: bool = False,
     ):
         """
         Initialize MimicIV-ECG Dataset.
@@ -75,6 +76,8 @@ class MimicIVECGDataset(QADataset):
             pre_prompt_template: Optional template for pre-prompt. Can use {question} placeholder.
             post_prompt_template: Optional template for post-prompt.
             fix_lead_order: If True, reorder leads to match ECG-QA order (I, II, III, aVR, aVL, aVF, V1-V6)
+            use_custom_prompt_directly: If True, use custom prompt as-is without default wrapper. 
+                                      When True, pre_prompt_template and post_prompt_template are ignored.
         """
         self.max_samples = max_samples
         self.ecg_data_dir = ecg_data_dir
@@ -82,6 +85,7 @@ class MimicIVECGDataset(QADataset):
         self.pre_prompt_template = pre_prompt_template
         self.post_prompt_template = post_prompt_template
         self.fix_lead_order = fix_lead_order
+        self.use_custom_prompt_directly = use_custom_prompt_directly
         
         # Override parent initialization to handle NaN samples
         self.EOS_TOKEN = EOS_TOKEN
@@ -178,6 +182,10 @@ class MimicIVECGDataset(QADataset):
             # Single string: use for all samples
             question = str(self.custom_prompts)
         
+        # If use_custom_prompt_directly is True, return the prompt as-is
+        if self.use_custom_prompt_directly:
+            return question.strip()
+        
         # Use template if provided
         if self.pre_prompt_template:
             pre_prompt = self.pre_prompt_template.format(question=question)
@@ -201,6 +209,10 @@ Instructions:
 
     def _get_post_prompt(self, row) -> str:
         """Generate the post-prompt with instructions."""
+        # If use_custom_prompt_directly is True, return empty post-prompt
+        if self.use_custom_prompt_directly:
+            return ""
+        
         if self.post_prompt_template:
             return self.post_prompt_template.strip()
         

--- a/src/opentslm/time_series_datasets/mimiciv_ecg/__init__.py
+++ b/src/opentslm/time_series_datasets/mimiciv_ecg/__init__.py
@@ -1,0 +1,33 @@
+# SPDX-FileCopyrightText: 2025 Stanford University, ETH Zurich, and the project authors (see CONTRIBUTORS.md)
+# SPDX-FileCopyrightText: 2025 This source file is part of the OpenTSLM open-source project.
+#
+# SPDX-License-Identifier: MIT
+
+"""
+MimicIV-ECG Dataset Module
+
+This module provides tools for working with the MimicIV-ECG dataset for medical AI tasks.
+
+Usage:
+    from opentslm.time_series_datasets.mimiciv_ecg.MimicIVECGDataset import MimicIVECGDataset
+    
+    # Create dataset instance
+    dataset = MimicIVECGDataset(split="test", EOS_TOKEN="", custom_prompts=["Does this ECG show atrial fibrillation?"])
+    
+    # Access samples
+    sample = dataset[0]
+"""
+
+from .MimicIVECGDataset import MimicIVECGDataset
+from .mimiciv_ecg_loader import (
+    load_mimiciv_ecg_splits,
+    get_mimiciv_ecg_path,
+    load_mimiciv_ecg_answers,
+)
+
+__all__ = [
+    "MimicIVECGDataset",
+    "load_mimiciv_ecg_splits",
+    "get_mimiciv_ecg_path",
+    "load_mimiciv_ecg_answers",
+]

--- a/src/opentslm/time_series_datasets/mimiciv_ecg/mimiciv_ecg_loader.py
+++ b/src/opentslm/time_series_datasets/mimiciv_ecg/mimiciv_ecg_loader.py
@@ -1,0 +1,189 @@
+# SPDX-FileCopyrightText: 2025 Stanford University, ETH Zurich, and the project authors (see CONTRIBUTORS.md)
+# SPDX-FileCopyrightText: 2025 This source file is part of the OpenTSLM open-source project.
+#
+# SPDX-License-Identifier: MIT
+
+import os
+import json
+import pandas as pd
+from typing import Tuple, Dict, List, Optional
+from datasets import Dataset
+from tqdm import tqdm
+
+from opentslm.time_series_datasets.constants import RAW_DATA as RAW_DATA_PATH
+
+
+# MimicIV-ECG Directory - completely independent from ECG-QA
+# The data is located at /home/lastchance/Desktop/mimiciv
+MIMICIV_ECG_BASE_DIR = "/home/lastchance/Desktop/mimiciv/mimic-iv-ecg-diagnostic-electrocardiogram-matched-subset-1.0"
+
+# Default path for ECG data files (.dat/.hea) - same directory or subdirectory
+DEFAULT_MIMICIV_ECG_DATA_DIR = MIMICIV_ECG_BASE_DIR
+
+
+def get_mimiciv_ecg_path(ecg_id: int, ecg_data_dir: Optional[str] = None) -> str:
+    """
+    Get the file path for a MimicIV-ECG record.
+    
+    MimicIV-ECG structure: files/p{patient}/p{patient}/s{session}/{ecg_id}.dat
+    
+    Args:
+        ecg_id: The ECG record ID
+        ecg_data_dir: Optional directory containing ECG data files. 
+                     If None, uses DEFAULT_MIMICIV_ECG_DATA_DIR
+    
+    Returns:
+        Base path to the ECG record (without .dat/.hea extension)
+    """
+    if ecg_data_dir is None:
+        ecg_data_dir = DEFAULT_MIMICIV_ECG_DATA_DIR
+    
+    files_dir = os.path.join(ecg_data_dir, "files")
+    
+    # Search for the ECG file by walking the directory structure
+    # Format: files/p{patient}/p{patient}/s{session}/{ecg_id}.dat
+    ecg_id_str = str(ecg_id)
+    for root, dirs, files in os.walk(files_dir):
+        for file in files:
+            if file == f"{ecg_id_str}.dat":
+                base_path = os.path.join(root, ecg_id_str)
+                if os.path.exists(base_path + ".hea"):
+                    return base_path
+    
+    # If not found, return a path that will fail with a clear error
+    return os.path.join(files_dir, "not_found", str(ecg_id))
+
+
+def load_mimiciv_ecg_splits(
+    ecg_data_dir: Optional[str] = None,
+    max_samples: Optional[int] = None
+) -> Tuple[Dataset, Dataset, Dataset]:
+    """
+    Load all MimicIV-ECG files by scanning for ECG files.
+    
+    Since we use custom prompts, we don't need JSON files with questions.
+    We just scan for all available ECG files and create samples from them.
+    Returns all samples as a single dataset (same for train/val/test).
+    
+    Args:
+        ecg_data_dir: Optional directory containing ECG data files.
+                     If None, uses DEFAULT_MIMICIV_ECG_DATA_DIR
+        max_samples: Optional maximum number of samples (for testing)
+    
+    Returns:
+        Tuple of (train_dataset, val_dataset, test_dataset) - all contain the same data
+    """
+    if ecg_data_dir is None:
+        ecg_data_dir = DEFAULT_MIMICIV_ECG_DATA_DIR
+    
+    if not os.path.exists(ecg_data_dir):
+        raise FileNotFoundError(
+            f"MimicIV-ECG data directory not found at {ecg_data_dir}. "
+            f"Please ensure the data is available."
+        )
+    
+    # Find all ECG .dat files
+    files_dir = os.path.join(ecg_data_dir, "files")
+    if not os.path.exists(files_dir):
+        raise FileNotFoundError(
+            f"ECG files directory not found at {files_dir}. "
+            f"Expected structure: {ecg_data_dir}/files/p*/p*/s*/*.dat"
+        )
+    
+    print("Scanning for ECG files...")
+    ecg_files = []
+    for root, dirs, files in os.walk(files_dir):
+        for file in files:
+            if file.endswith('.dat'):
+                base_path = os.path.join(root, file.replace('.dat', ''))
+                hea_path = base_path + '.hea'
+                if os.path.exists(hea_path):
+                    ecg_files.append(base_path)
+    
+    print(f"Found {len(ecg_files)} ECG files")
+    
+    if not ecg_files:
+        raise ValueError(f"No ECG files found in {files_dir}")
+    
+    # Extract ECG ID from file path (e.g., .../s46394165/46394165 -> 46394165)
+    def extract_ecg_id(file_path: str) -> int:
+        """Extract ECG ID from file path."""
+        # Path format: .../s{ecg_id}/{ecg_id}
+        parts = file_path.split('/')
+        for part in reversed(parts):
+            if part.isdigit():
+                return int(part)
+        # Fallback: use filename
+        filename = os.path.basename(file_path)
+        if filename.isdigit():
+            return int(filename)
+        raise ValueError(f"Could not extract ECG ID from path: {file_path}")
+    
+    # Create samples from ECG files
+    all_samples = []
+    for ecg_file in tqdm(ecg_files, desc="Creating samples"):
+        try:
+            ecg_id = extract_ecg_id(ecg_file)
+            sample = {
+                'ecg_id': [ecg_id],
+                'ecg_paths': [ecg_file + '.dat'],
+                'sample_id': len(all_samples),
+            }
+            all_samples.append(sample)
+        except Exception as e:
+            print(f"Warning: Skipping {ecg_file}: {e}")
+            continue
+    
+    # Limit samples if requested
+    if max_samples and len(all_samples) > max_samples:
+        print(f"Limiting to {max_samples} samples...")
+        all_samples = all_samples[:max_samples]
+    
+    print(f"Total samples: {len(all_samples)}")
+    
+    # Convert to HuggingFace dataset - return same dataset for all splits
+    print("Converting to HuggingFace dataset...")
+    dataset = Dataset.from_list(all_samples)
+    
+    print("Dataset loading complete!")
+    return dataset, dataset, dataset
+
+
+def load_mimiciv_ecg_answers() -> pd.DataFrame:
+    """Load the answers mapping for MimicIV-ECG."""
+    if not os.path.exists(MIMICIV_ECG_BASE_DIR):
+        raise FileNotFoundError(
+            f"MimicIV-ECG directory not found at {MIMICIV_ECG_BASE_DIR}"
+        )
+    
+    answers_path = os.path.join(MIMICIV_ECG_BASE_DIR, "answers.csv")
+    if not os.path.exists(answers_path):
+        raise FileNotFoundError(f"Answers file not found: {answers_path}")
+    
+    return pd.read_csv(answers_path)
+
+
+if __name__ == "__main__":
+    # Test the loader
+    print("Testing MimicIV-ECG loader...")
+    
+    try:
+        train, val, test = load_mimiciv_ecg_splits(max_samples=10)
+        print(f"Loaded MimicIV-ECG dataset:")
+        print(f"  Train: {len(train)} samples")
+        print(f"  Validation: {len(val)} samples")
+        print(f"  Test: {len(test)} samples")
+        
+        if len(train) > 0:
+            print(f"\nSample from training set:")
+            sample = train[0]
+            for key, value in sample.items():
+                if isinstance(value, list) and len(value) > 3:
+                    print(f"  {key}: {value[:3]}... ({len(value)} items)")
+                else:
+                    print(f"  {key}: {value}")
+                    
+    except Exception as e:
+        print(f"Error loading dataset: {e}")
+        import traceback
+        traceback.print_exc()


### PR DESCRIPTION
# OpenTSLM-Flamingo SimpleNamespace fix

## :recycle: Current situation & Problem
* Since we refactored to UV, OpenTSLM Flamingo models were wrapped wrongly inside a SimpleNamespace failing with "AttributeError: 'types.SimpleNamespace' object has no attribute 'requires_grad_' " during training or inference.

## :gear: Release Notes
* Adds a workaround to pull out the actual encoder from underneath the SimpleNamespace



### Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [ X] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).