### PR TITLE
Multi-GPU training does not data-parallelize: the DDP wrapper is bypassed

### DIFF
--- a/curriculum_learning.py
+++ b/curriculum_learning.py
@@ -1115,6 +1115,15 @@ class CurriculumTrainer:
                     loss = self._get_model().compute_loss(batch)
                     loss.backward()
 
+                    # _get_model() unwraps DDP, so its gradient sync is bypassed; average grads manually.
+                    if dist.is_initialized():
+                        for p in self._get_model().parameters():
+                            if not p.requires_grad:
+                                continue
+                            if p.grad is None:
+                                p.grad = torch.zeros_like(p)
+                            dist.all_reduce(p.grad, op=dist.ReduceOp.AVG)
+
                     # Handle gradient clipping for distributed training
                     clip_grad_norm_(self._get_model().parameters(), GRAD_CLIP_NORM)
 


### PR DESCRIPTION
cc @RealLast

## :recycle: Current situation & Problem

`curriculum_learning.py` wraps the model in `DDP(model)`, but every training step computes the loss on the **unwrapped** module:

```python
loss = self._get_model().compute_loss(batch)   # _get_model() returns self.model.module
loss.backward()
```
Calling the module instead of the wrapper means DDP's reducer never fires, so gradients are never synchronized across ranks. With `DistributedSampler` sharding the data, each rank trains an independent replica on its own 1/N of the data, `_save_checkpoint` keeps only rank 0, and ranks 1…N−1's training is discarded.


## :gear: Release Notes

- Multi-GPU (DDP) training now synchronizes gradients across ranks (manual all-reduce after `backward()`); previously each rank trained an independent replica and only rank 0 was saved.



## :books: Documentation

A one-line inline comment at the fix site explains why the manual all-reduce is needed (the `_get_model()` unwrap bypasses DDP). No public-interface change.

## :white_check_mark: Testing

The toy below replicates the trainer's exact pattern — `DDP(model)` wrapped (as in `_initialize_model`), loss computed on `model.module` (as in `_get_model().compute_loss(...)`), and a different data shard per rank (as `DistributedSampler` gives) — then logs the gradient each rank holds and how far the two ranks' weights have drifted apart.

```python
import torch, torch.distributed as dist, torch.nn as nn
dist.init_process_group("nccl"); r, W = dist.get_rank(), dist.get_world_size(); torch.cuda.set_device(r)

def trajectory(fix, steps=5):
    torch.manual_seed(0); m = nn.Linear(4, 4).cuda()                 # identical init on both ranks
    ddp = nn.parallel.DistributedDataParallel(m, device_ids=[r]); gm = lambda: ddp.module
    opt = torch.optim.SGD(m.parameters(), lr=0.05)
    out = []
    for s in range(steps):
        g = torch.Generator(device="cuda").manual_seed(1000 + s)
        x = torch.randn(4, 4, generator=g, device="cuda") * 0.5 + r  # a different shard per rank
        y = torch.randn(4, 4, generator=torch.Generator(device="cuda").manual_seed(s), device="cuda")
        opt.zero_grad(); ((gm()(x) - y) ** 2).mean().backward()      # loss on module == the trainer's path
        if fix:                                                       # the proposed fix
            for p in gm().parameters():
                if p.grad is not None: dist.all_reduce(p.grad, op=dist.ReduceOp.AVG)
        gw = gm().weight.grad.flatten()[0].clone(); opt.step()
        w = m.weight.flatten()
        gws = [torch.zeros_like(gw) for _ in range(W)]; dist.all_gather(gws, gw)
        ws  = [torch.zeros_like(w)  for _ in range(W)]; dist.all_gather(ws, w)
        out.append((gws[0].item(), gws[1].item(), (ws[0]-ws[1]).abs().max().item()))
    return out

B, F = trajectory(False), trajectory(True)
if r == 0:
    print("Table 1 - gradient on weight[0] after backward, per rank:")
    print(f"{'step':>4} | {'BUGGY g_r0':>11} {'g_r1':>11} {'synced':>7} | {'FIXED g_r0':>11} {'g_r1':>11} {'synced':>7}")
    for i,((b0,b1,_),(f0,f1,_)) in enumerate(zip(B,F),1):
        print(f"{i:>4} | {b0:>11.5f} {b1:>11.5f} {str(abs(b0-b1)<1e-9):>7} | {f0:>11.5f} {f1:>11.5f} {str(abs(f0-f1)<1e-9):>7}")
    print("\nTable 2 - cross-rank model divergence max|W_rank0 - W_rank1| after each step:")
    print(f"{'step':>4} | {'BUGGY':>12} | {'FIXED':>12}")
    for i,((_,_,bd),(_,_,fd)) in enumerate(zip(B,F),1):
        print(f"{i:>4} | {bd:>12.6f} | {fd:>12.6f}")
dist.destroy_process_group()
```

Output:
```
Table 1 - gradient on weight[0] after backward, per rank:
step |  BUGGY g_r0        g_r1  synced |  FIXED g_r0        g_r1  synced
   1 |     0.04043     0.19431   False |     0.11737     0.11737    True
   2 |    -0.13683    -0.05685   False |    -0.09659    -0.09659    True
   3 |     0.05426    -0.25685   False |    -0.10196    -0.10196    True
   4 |     0.02004    -0.01721   False |    -0.00963    -0.00963    True
   5 |    -0.21217    -0.45084   False |    -0.34623    -0.34623    True

Table 2 - cross-rank model divergence max|W_rank0 - W_rank1| after each step:
step |        BUGGY |        FIXED
   1 |     0.050678 |     0.000000
   2 |     0.073750 |     0.000000
   3 |     0.093219 |     0.000000
   4 |     0.118547 |     0.000000
   5 |     0.132573 |     0.000000
```

- **Buggy** (loss on `model.module`): each rank holds different gradients (`synced=False`), takes a different step, and the replicas drift apart — divergence grows every step and keeps climbing.
- **Fixed** (`+ all-reduce`): gradients are identical across ranks and equal the **average** of the per-rank grads (step 1: `(0.04043 + 0.19431) / 2 = 0.11737`), so the replicas stay bit-identical (`0.000000`).

The same divergence also reproduces on the actual pipeline; the two ranks diverge after the first step under the current loop and stay identical with the fix:
```
BUGGY (current code: loss on _get_model(), no all-reduce)
step | per-rank grad norm     | grad_synced | weight drift across ranks
  0  | [29.180, 29.762]       |   False     |  0.000e+00
  1  | [30.274, 29.429]       |   False     |  0.000e+00
  2  | [30.679, 29.582]       |   False     |  1.769e-04
  3  | [28.949, 29.850]       |   False     |  3.611e-04

FIXED (+ all-reduce grads after backward)
step | per-rank grad norm     | grad_synced | weight drift across ranks
  0  | [28.969, 28.969]       |   True      |  0.000e+00
  1  | [29.689, 29.689]       |   True      |  0.000e+00
  2  | [29.913, 29.913]       |   True      |  0.000e+00
  3  | [29.223, 29.223]       |   True      |  0.000e+00
```
### Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/SchmiedmayerLab/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/SchmiedmayerLab/.github/blob/main/CONTRIBUTING.md):
- [X] I agree to follow the [Code of Conduct](https://github.com/SchmiedmayerLab/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/SchmiedmayerLab/.github/blob/main/CONTRIBUTING.md).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/SchmiedmayerLab/codesmith/OpenTSLM/pr/49"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785189605&installation_id=142325556&pr_number=49&repository=SchmiedmayerLab%2FOpenTSLM&return_to=https%3A%2F%2Fgithub.com%2FSchmiedmayerLab%2FOpenTSLM%2Fpull%2F49&signature=0a5b566f297642e86185bd6bf4b164a34d14728b07bdda03b999b166740cd30e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved multi-device training stability by explicitly synchronizing gradients and averaging them across processes immediately after backpropagation during stage training.
  - This helps ensure consistent parameter updates across multiple devices, leading to more reliable and reproducible results in distributed runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->